### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "6to5-jest",
   "version": "3.0.0",
+  "repository": "6to5/6to5-jest",
   "dependencies": {
     "6to5-core": "^3.0.0"
   }


### PR DESCRIPTION
This should shut up at least one npm warning.